### PR TITLE
Reduce transaction failure rate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,26 @@ jobs:
       - checkout
       - run:
           name: Upload Harmony Library
-          command: ./gradlew :library:bintrayUpload
+          command: |
+            echo $SIGNING_SECRET | base64 -d > ~/secret.gpg
+            ./gradlew :library:publishReleaseHarmonyPublicationToSonatypeRepository
+
+  Android-Library-Maven-Release:
+    docker:
+      - image: circleci/android:api-29
+
+    environment:
+      # Configure the JVM and Gradle to avoid OOM errors
+      _JAVA_OPTIONS: "-Xmx3g"
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run:
+          name: Release Harmony Library
+          command: ./gradlew closeAndReleaseRepository
 
 workflows:
   version: 2
@@ -109,4 +128,10 @@ workflows:
             branches:
               only:
                 - main
-
+      - Android-Library-Maven-Release:
+          requires:
+            - Android-Library-Upload
+          filters:
+            branches:
+              only:
+                - main

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Inter-Process replication test setup:
 
 ## Change Log
 ### Version 1.1.4 / 2021-02-10
-- Added `fsync()` for each transaction written (in response to #15)
+- Added `fsync()` for each transaction written (in response to [#15](https://github.com/pablobaxter/Harmony/issues/15))
 - Minor restructure for reading JSON string from main file
 - Updated Kotlin libraries and Android plugins
 - Migrated to releasing directly to MavenCentral instead of Bintray

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Inter-Process replication test setup:
 
 ## Change Log
 ### Version 1.1.4 / 2021-02-10
-- Added `fsync()` for each transaction written (in response to [#15](https://github.com/pablobaxter/Harmony/issues/15))
+- Added `FileDescriptor.sync()` for each transaction written (in response to [#15](https://github.com/pablobaxter/Harmony/issues/15))
 - Minor restructure for reading JSON string from main file
 - Updated Kotlin libraries and Android plugins
 - Migrated to releasing directly to MavenCentral instead of Bintray

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Inter-Process replication test setup:
 **Summary:** With the recent changes (`v1.1.3`), Harmony `apply()` is as fast as the vanilla `SharedPreferences` and the replication performance across processes has been greatly improved. Previously, this replication would take up to 3 seconds when calling `apply()` upwards of 1k times, but now will take ~350 ms at maximum.
 
 ## Change Log
+### Version 1.1.4 / 2021-02-10
+- Added `fsync()` for each transaction written (in response to #15)
+- Minor restructure for reading JSON string from main file
+
 ### Version 1.1.3 / 2021-01-02
 - **MIN SDK Raised to API 17**
 - Adds batching to transactions, making inter-process data replication much faster

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Harmony Preferences
 [![CircleCI](https://circleci.com/gh/pablobaxter/Harmony/tree/main.svg?style=shield)](https://circleci.com/gh/pablobaxter/Harmony/tree/main)
 ![GitHub](https://img.shields.io/github/license/pablobaxter/harmony)
-![Bintray](https://img.shields.io/bintray/v/soaboz/Harmony/com.frybits.harmony?style=shield) [![API](https://img.shields.io/badge/API-17%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=17)
+![Maven-Central](https://img.shields.io/maven-central/v/com.frybits.harmony/harmony/1.1.4) [![API](https://img.shields.io/badge/API-17%2B-brightgreen.svg?style=flat)](https://android-arsenal.com/api?level=17)
 
 Working on multiprocess Android apps is a complex undertaking. One of the biggest challenges is managing shared data between the multiple processes. Most solutions rely on one process to be available for another to read the data, which can be quite slow and could potentially lead to ANRs.
 
@@ -17,9 +17,10 @@ Harmony is a thread-safe, process-safe, full [`SharedPreferences`](https://devel
 - Supports Android API 17+
 
 ## Download
+The latest release is available on [Maven Central](https://search.maven.org/artifact/com.frybits.harmony/harmony/1.1.4/aar).
 ### Gradle
 ```
-implementation 'com.frybits.harmony:harmony:1.1.3'
+implementation 'com.frybits.harmony:harmony:1.1.4'
 ```
 
 ## Usage
@@ -98,6 +99,8 @@ Inter-Process replication test setup:
 ### Version 1.1.4 / 2021-02-10
 - Added `fsync()` for each transaction written (in response to #15)
 - Minor restructure for reading JSON string from main file
+- Updated Kotlin libraries and Android plugins
+- Migrated to releasing directly to MavenCentral instead of Bintray
 
 ### Version 1.1.3 / 2021-01-02
 - **MIN SDK Raised to API 17**

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ android {
 
 dependencies {
     implementation project (':library')
-//    implementation 'com.frybits.harmony:harmony:1.1.3'
+//    implementation 'com.frybits.harmony:harmony:1.1.4'
 
     // Kotlin
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion compileSdk_version

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
         targetSdk_version = 30
         buildtools_version = '29.0.2'
 
-        version_name = "1.1.3"
+        version_name = "1.1.4"
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript { 
 
     ext {
-        kotlin_version = '1.4.21'
+        kotlin_version = '1.4.30'
         kotlin_coroutine_version = '1.4.2'
         lifecycle_scope_version = '2.2.0'
 
@@ -36,19 +36,21 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.10.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
+        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.4.20'
+        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
 }
 
+apply plugin: 'io.codearte.nexus-staging'
+
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ buildscript {
 
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
 
@@ -51,6 +52,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        jcenter()
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,9 +1,8 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'org.jetbrains.dokka'
-apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 android {
     compileSdkVersion compileSdk_version
@@ -41,24 +40,23 @@ android {
     }
 }
 
-dokka {
-    outputFormat = 'html'
-    outputDirectory = "$buildDir/dokka"
+dokkaHtml {
+    moduleName.set('Harmony')
+    dokkaSourceSets {
+        named("main") {
+            noAndroidSdkLink.set(false)
+            outputDirectory.set(file("$buildDir/dokka"))
+            reportUndocumented.set(true)
+            platform.set(org.jetbrains.dokka.Platform.jvm)
+            sourceRoots.setFrom(file("src/main"))
+            jdkVersion.set(8)
 
-    configuration {
-        moduleName = 'data'
-        reportUndocumented = true
-        platform = "JVM"
-        sourceRoot {
-            path = "src/main"
-        }
-        jdkVersion = 8
-
-        perPackageOption {
-            prefix = "kotlin"
-            skipDeprecated = false
-            reportUndocumented = true
-            includeNonPublic = false
+            perPackageOption {
+                matchingRegex('kotlin($|\\.).*')
+                skipDeprecated.set(false)
+                eportUndocumented.set(true)
+                includeNonPublic.set(false)
+            }
         }
     }
 }
@@ -69,7 +67,7 @@ task sourcesJar(type: Jar) {
     archiveClassifier = 'sources'
 }
 
-task javadocJar(type: Jar, dependsOn: dokka) {
+task javadocJar(type: Jar, dependsOn: dokkaHtml) {
     from "$buildDir/dokka"
     archiveClassifier = 'javadoc'
 }
@@ -97,6 +95,29 @@ dependencies {
     androidTestUtil "androidx.test:orchestrator:$test_orchestrator_version"
 }
 
+ext["signing.keyId"] = ''
+ext["signing.password"] = ''
+ext["signing.secretKeyRingFile"] = ''
+ext["ossrhUsername"] = ''
+ext["ossrhPassword"] = ''
+
+File secretPropsFile = project.rootProject.file('local.properties')
+if (secretPropsFile.exists()) {
+    println "Found secret props file, loading props"
+    Properties p = new Properties()
+    p.load(new FileInputStream(secretPropsFile))
+    p.each { name, value ->
+        ext[name] = value
+    }
+} else {
+    println "No props file, loading env vars"
+    ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
+    ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
+    ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_SECRET_KEY_RING_FILE')
+    ext["ossrhUsername"] = System.getenv('MAVEN_USERNAME')
+    ext["ossrhPassword"] = System.getenv('MAVEN_PASSWORD')
+}
+
 afterEvaluate {
     publishing {
         publications {
@@ -117,62 +138,52 @@ afterEvaluate {
                     archiveClassifier = 'javadoc'
                 }
 
-                pom.withXml { pom ->
-                    def root = asNode()
-                    root.appendNode('name', 'Harmony')
-                    root.appendNode('description', 'A process-safe SharedPreferences implementation')
-                    root.appendNode('url', 'https://github.com/pablobaxter/Harmony')
-                    def license = root.appendNode('licenses').appendNode('license')
-                    license.appendNode('name', 'Apache License, Version 2.0')
-                    license.appendNode('url', 'https://opensource.org/licenses/Apache-2.0')
-                    def developer = root.appendNode('developers').appendNode('developer')
-                    developer.appendNode('id', 'soaboz')
-                    developer.appendNode('name', 'Pablo Baxter')
-                    developer.appendNode('email', 'pablo@frybits.com')
-                    def scm = root.appendNode('scm')
-                    scm.appendNode('connection', 'scm:git:git://github.com/pablobaxter/Harmony.git')
-                    scm.appendNode('developerConnection', 'git:ssh://github.com/pablobaxter/Harmony.git')
-                    scm.appendNode('url', 'https://github.com/pablobaxter/Harmony')
+                pom {
+                    name = 'Harmony'
+                    description = 'A process-safe SharedPreferences implementation'
+                    url = 'https://github.com/pablobaxter/Harmony'
+                    licenses {
+                        license {
+                            name = 'The Apache License, Version 2.0'
+                            url = 'https://opensource.org/licenses/Apache-2.0'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'soaboz'
+                            name = 'Pablo Baxter'
+                            email = 'pablo@frybits.com'
+                        }
+                    }
+                    scm {
+                        connection = 'scm:git:git://github.com/pablobaxter/Harmony.git'
+                        developerConnection = 'git:ssh://github.com/pablobaxter/Harmony.git'
+                        url = 'https://github.com/pablobaxter/Harmony'
+                    }
+                }
+            }
+        }
+        repositories {
+            // The repository to publish to, Sonatype/MavenCentral
+            maven {
+                name = "sonatype"
+                url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                credentials {
+                    username ossrhUsername
+                    password ossrhPassword
                 }
             }
         }
     }
 }
 
-bintray {
-    //Gets local.properties info
-    Properties properties = new Properties()
-    def propertiesFile = project.rootProject.file('local.properties')
-    if (propertiesFile.exists()) {
-        properties.load(propertiesFile.newDataInputStream())
-    }
+signing {
+    sign publishing.publications
+}
 
-    //Assigns credentials
-    user = properties.getProperty('bintray.user') ?: System.getenv('BINTRAY_USER')
-    key = properties.getProperty('bintray.apiKey') ?: System.getenv('BINTRAY_API_KEY')
-
-    //Only interested in the JVM for now
-    //Only want the Android AARs
-    publications = ['releaseHarmony']
-
-    // Default: false. Whether to run this as dry-run, without deploying
-    dryRun = false
-    // Default: false. Whether to override version artifacts already published
-    override = false
-    // Default: false. Whether version should be auto published after an upload
-    publish = true
-
-    pkg {
-        repo = 'Harmony' // the name of the repository you created on Bintray
-        name = 'com.frybits.harmony' // the name of the package you created inside it
-        desc = 'A process-safe SharedPreferences implementation'
-        licenses = ['Apache-2.0']
-        vcsUrl = 'https://github.com/pablobaxter/Harmony.git'
-        githubRepo = 'pablobaxter/Harmony' //Optional Github repository
-        version {
-            name = version_name
-            released = new Date()
-            vcsTag = version_name
-        }
-    }
+nexusStaging {
+    packageGroup = 'com.frybits.harmony'
+    stagingProfileId = '38e43065571d'
+    username = ossrhUsername
+    password = ossrhPassword
 }

--- a/library/src/androidTest/java/com/frybits/harmony/HarmonyJsonUtilsTest.kt
+++ b/library/src/androidTest/java/com/frybits/harmony/HarmonyJsonUtilsTest.kt
@@ -1,7 +1,5 @@
 package com.frybits.harmony
 
-import android.util.JsonReader
-import android.util.JsonWriter
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.frybits.harmony.internal.putHarmony
 import com.frybits.harmony.internal.readHarmony
@@ -91,28 +89,28 @@ class HarmonyUtilsTest {
 
     @Test
     fun basicJsonToHarmonyMapTest() {
-        val map = JsonReader(StringReader(BASIC_JSON)).readHarmony()
+        val map = StringReader(BASIC_JSON).readHarmony()
         assertEquals(BASIC_MAP, map.second, "Maps were not equal")
     }
 
     @Test
     fun basicHarmonyMapToJsonTest() {
         val stringWriter = StringWriter()
-        JsonWriter(stringWriter).putHarmony(BASIC_NAME, BASIC_MAP).flush()
+        stringWriter.putHarmony(BASIC_NAME, BASIC_MAP).flush()
         val expected = JSONObject(BASIC_JSON).toString()
         assertEquals(expected, stringWriter.toString(), "JSON strings were not equal")
     }
 
     @Test
     fun mixedJsonToHarmonyMapTest() {
-        val map = JsonReader(StringReader(MIXED_JSON)).readHarmony()
+        val map = StringReader(MIXED_JSON).readHarmony()
         assertEquals(MIXED_MAP, map.second, "Maps were not equal")
     }
 
     @Test
     fun mixedHarmonyMapToJsonTest() {
         val stringWriter = StringWriter()
-        JsonWriter(stringWriter).putHarmony(MIXED_NAME, MIXED_MAP).flush()
+        stringWriter.putHarmony(MIXED_NAME, MIXED_MAP).flush()
         val expected = JSONObject(MIXED_JSON).toString()
         assertEquals(expected, stringWriter.toString(), "JSON strings were not equal")
     }
@@ -133,9 +131,9 @@ class HarmonyUtilsTest {
         )
 
         val stringWriter = StringWriter()
-        JsonWriter(stringWriter).putHarmony(expectedName, expectedMap).flush()
+        stringWriter.putHarmony(expectedName, expectedMap).flush()
 
-        val map = JsonReader(StringReader(stringWriter.toString())).readHarmony()
+        val map = StringReader(stringWriter.toString()).readHarmony()
         assertEquals(expectedMap, map.second, "Maps were not equal")
     }
 }

--- a/library/src/main/java/com/frybits/harmony/Harmony.kt
+++ b/library/src/main/java/com/frybits/harmony/Harmony.kt
@@ -6,8 +6,6 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.os.FileObserver
 import android.os.SystemClock
-import android.util.JsonReader
-import android.util.JsonWriter
 import androidx.annotation.GuardedBy
 import androidx.annotation.VisibleForTesting
 import com.frybits.harmony.internal._InternalHarmonyLog
@@ -277,7 +275,7 @@ private class HarmonyImpl constructor(
     // Helper function to handle exceptions from reading the main file
     private fun readHarmonyMapFromStream(prefsReader: Reader): Pair<String?, Map<String, Any?>> {
         return try {
-            JsonReader(prefsReader).readHarmony()
+            prefsReader.readHarmony()
         } catch (e: IllegalStateException) {
             _InternalHarmonyLog.e(LOG_TAG, "IllegalStateException while reading data file", e)
             null to emptyMap()
@@ -350,7 +348,7 @@ private class HarmonyImpl constructor(
 
                 try {
                     harmonyMainFile.outputStream().use { mainOutputStream ->
-                        JsonWriter(mainOutputStream.bufferedWriter())
+                        mainOutputStream.bufferedWriter()
                             .putHarmony(prefsName, mainSnapshot)
                             .flush()
                         // Write all changes to the physical storage
@@ -631,7 +629,7 @@ private class HarmonyImpl constructor(
 
         try {
             harmonyMainFile.outputStream().use { mainOutputStream ->
-                JsonWriter(mainOutputStream.bufferedWriter())
+                mainOutputStream.bufferedWriter()
                     .putHarmony(prefsName, currentPrefs)
                     .flush()
                 // Write all changes to the physical storage


### PR DESCRIPTION
Due to the issue of #15, we are now syncing the `FileDescriptor` before closing after each transaction write. This has negligible impact on cross-process syncing delay, and reduces the number of transactions failures to ~6 out of every ~10M transactions. Given the rarity of this issue, I will be closing #15, with this PR as the fix.

This PR also migrates away from using Bintray for uploading the binaries and moves to using MavenCentral explicitly.