### PR TITLE
Emit null in OnSharedPreferenceChangeListener when preferences are cleared.

### DIFF
--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -10,7 +10,6 @@ android {
 
     defaultConfig {
         minSdkVersion crypto_minSdk_version
-        targetSdkVersion targetSdk_version
         versionName crypto_version_name
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/harmony/build.gradle
+++ b/harmony/build.gradle
@@ -10,7 +10,6 @@ android {
 
     defaultConfig {
         minSdkVersion harmony_minSdk_version
-        targetSdkVersion targetSdk_version
         versionName harmony_version_name
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/harmony/src/androidTest/AndroidManifest.xml
+++ b/harmony/src/androidTest/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.frybits.harmony">
 
+    <uses-sdk android:targetSdkVersion="30"/>
+
     <application>
         <service
             android:name=".AlternateProcessService"

--- a/harmony/src/androidTest/java/com/frybits/harmony/HarmonyProcessCommitTest.kt
+++ b/harmony/src/androidTest/java/com/frybits/harmony/HarmonyProcessCommitTest.kt
@@ -477,8 +477,15 @@ class HarmonyProcessCommitTest {
         assertTrue { sharedPreferences.edit().putString(TEST_CLEAR_DATA_KEY, clearDataTestString).commit() } // Pre-populate the prefs with known data
 
         val clearDataKeyChangedCompletableDeferred = CompletableDeferred<String?>()
+        val clearEmittedNullValue = CompletableDeferred<Boolean>()
 
         val clearDataChangeListener = SharedPreferences.OnSharedPreferenceChangeListener { prefs, key ->
+            if (key == null) {
+                clearEmittedNullValue.complete(true)
+                return@OnSharedPreferenceChangeListener
+            } else if (!clearEmittedNullValue.isCompleted) {
+                clearEmittedNullValue.complete(false)
+            }
             assertTrue("Wrong Harmony object was returned") { sharedPreferences == prefs }
             assertTrue("Wrong key was emitted") { key == TEST_CLEAR_DATA_KEY } // We expect the change listener to emit, even though we have the same string. Prefs were cleared.
             clearDataKeyChangedCompletableDeferred.complete(prefs.getString(TEST_CLEAR_DATA_KEY, null))
@@ -492,7 +499,9 @@ class HarmonyProcessCommitTest {
         serviceRule.startService(serviceIntent)
 
         withTimeout(1000) {
+            val emittedNull = clearEmittedNullValue.await()
             val clearDataResponse = clearDataKeyChangedCompletableDeferred.await()
+            assertTrue(emittedNull, "Cleared data change listener didn't emit null first!")
             assertEquals(clearDataTestString, clearDataResponse, "Cleared data change listener failed to emit the correct key!")
         }
 

--- a/harmony/src/main/java/com/frybits/harmony/Harmony.kt
+++ b/harmony/src/main/java/com/frybits/harmony/Harmony.kt
@@ -5,6 +5,7 @@ package com.frybits.harmony
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.Build
 import android.os.FileObserver
 import android.os.Handler
 import android.os.HandlerThread
@@ -114,6 +115,8 @@ private class HarmonyImpl constructor(
 
     // The last read position of the transaction file. Prevents having to read the entire file each update.
     private var lastTransactionPosition = 0L
+
+    private val shouldNotifyClearToListeners = context.applicationContext.applicationInfo.targetSdkVersion >= Build.VERSION_CODES.R
 
     // Runnable to handle transactions. Used as an object to allow the Handler to remove from the queue. Prevents build up of this job in the looper.
     private var transactionUpdateJob = Runnable {
@@ -449,10 +452,14 @@ private class HarmonyImpl constructor(
                 val keysModified = if (notifyListeners) arrayListOf<String>() else null
                 val listeners = if (notifyListeners) listenerMap.keys.toSet() else null
 
+                var wasCleared = false
                 // Commit all transactions to this snapshot
                 combinedTransactions.forEach { transaction ->
                     val tempTransaction = lastTransaction
                     if (tempTransaction < transaction) {
+                        if (transaction.cleared) {
+                            wasCleared = true
+                        }
                         transaction.commitTransaction(mainCopy, keysModified)
                         lastTransaction = transaction
                     } else {
@@ -465,6 +472,11 @@ private class HarmonyImpl constructor(
                 if (notifyListeners) {
                     requireNotNull(keysModified)
                     mainHandler.post { // Listeners are notified on the main thread
+                        if (shouldNotifyClearToListeners && wasCleared) {
+                            listeners?.forEach { listener ->
+                                listener.onSharedPreferenceChanged(this, null)
+                            }
+                        }
                         keysModified.asReversed().forEach { key ->
                             listeners?.forEach { listener ->
                                 listener.onSharedPreferenceChanged(this@HarmonyImpl, key)
@@ -531,6 +543,7 @@ private class HarmonyImpl constructor(
             val oldMap = harmonyMap
             harmonyMap = mainCopy
 
+            var wasCleared = false
             if (failedRead) { // Default to the old comparison logic
                 _InternalHarmonyLog.e(LOG_TAG, "Old transaction file was corrupted")
                 keysModified?.clear()
@@ -552,6 +565,9 @@ private class HarmonyImpl constructor(
                 combinedTransactions.forEach { transaction ->
                     val tempTransaction = lastTransaction
                     if (tempTransaction < transaction) {
+                        if (transaction.cleared) {
+                            wasCleared = true
+                        }
                         transaction.commitTransaction(oldMainSnapshot, keysModified)
                         lastTransaction = transaction
                     } else {
@@ -563,6 +579,11 @@ private class HarmonyImpl constructor(
             if (notifyListeners) {
                 requireNotNull(keysModified)
                 mainHandler.post { // Listeners are notified on the main thread
+                    if (shouldNotifyClearToListeners && wasCleared) {
+                        listeners?.forEach { listener ->
+                            listener.onSharedPreferenceChanged(this, null)
+                        }
+                    }
                     keysModified.asReversed().forEach { key ->
                         listeners?.forEach { listener ->
                             listener.onSharedPreferenceChanged(this@HarmonyImpl, key)
@@ -804,7 +825,7 @@ private class HarmonyImpl constructor(
                 val keysModified = if (notifyListeners) arrayListOf<String>() else null
                 val listeners = if (notifyListeners) listenerMap.keys.toSet() else null
 
-                synchronized(this@HarmonyEditor) {
+                val transaction = synchronized(this@HarmonyEditor) {
                     val transaction = harmonyTransaction
                     transaction.memoryCommitTime = SystemClock.elapsedRealtimeNanos() // The current time this "apply()" was called
                     transactionSet.add(transaction) // Add this to the in-flight transaction set for this process
@@ -812,12 +833,18 @@ private class HarmonyImpl constructor(
                     lastTransaction = maxOf(transaction, lastTransaction) // Extremely rare, but if the other process emitted a later transaction, keep that as the last, else use the current transaction
                     harmonyTransaction = HarmonyTransaction() // Generate a new transaction to prevent modifying one in-flight
                     transaction.commitTransaction(harmonyMap, keysModified) // Update the in-process map and get all modified keys
+                    return@synchronized transaction
                 }
 
                 // Notify this process of changes immediately
                 if (notifyListeners) {
                     requireNotNull(keysModified)
                     mainHandler.post { // Listeners are notified on the main thread
+                        if (shouldNotifyClearToListeners && transaction.cleared) {
+                            listeners?.forEach { listener ->
+                                listener.onSharedPreferenceChanged(this@HarmonyImpl, null)
+                            }
+                        }
                         keysModified.asReversed().forEach { key ->
                             listeners?.forEach { listener ->
                                 listener.onSharedPreferenceChanged(this@HarmonyImpl, key)
@@ -856,7 +883,8 @@ private class HarmonyTransaction(private val uuid: UUID = UUID.randomUUID()) : C
     private val transactionMap: HashMap<String, Operation> = hashMapOf()
 
     // Flag for cleared data
-    private var cleared = false
+    var cleared = false
+        private set
 
     // Used to ensure that transactions are applied in the order received
     var memoryCommitTime = 0L


### PR DESCRIPTION
Also removes targetSdk from library so that consumers can declare it.