### PR TITLE
Fix issue with crash due to bad transaction file

### DIFF
--- a/harmony/src/main/java/com/frybits/harmony/Harmony.kt
+++ b/harmony/src/main/java/com/frybits/harmony/Harmony.kt
@@ -1047,7 +1047,11 @@ private class HarmonyTransaction(private val uuid: UUID = UUID.randomUUID()) : C
                                 if (size == 0) {
                                     null
                                 } else {
-                                    val byteArray = ByteArray(size)
+                                    val byteArray = try {
+                                        ByteArray(size)
+                                    } catch (e: OutOfMemoryError) { // This was a bug with an old transaction file.
+                                        return transactionSet to true
+                                    }
                                     dataInputStream.read(byteArray)
                                     String(byteArray)
                                 }
@@ -1068,7 +1072,11 @@ private class HarmonyTransaction(private val uuid: UUID = UUID.randomUUID()) : C
                                 }
                                 TRANSACTION_FILE_VERSION_2 -> {
                                     val size = dataInputStream.readInt()
-                                    val byteArray = ByteArray(size)
+                                    val byteArray = try {
+                                        ByteArray(size)
+                                    } catch (e: OutOfMemoryError) { // This was a bug with an old transaction file.
+                                        return transactionSet to true
+                                    }
                                     dataInputStream.read(byteArray)
                                     String(byteArray)
                                 }
@@ -1087,7 +1095,11 @@ private class HarmonyTransaction(private val uuid: UUID = UUID.randomUUID()) : C
                                         }
                                         TRANSACTION_FILE_VERSION_2 -> {
                                             val size = dataInputStream.readInt()
-                                            val byteArray = ByteArray(size)
+                                            val byteArray = try {
+                                                ByteArray(size)
+                                            } catch (e: OutOfMemoryError) { // This was a bug with an old transaction file.
+                                                return transactionSet to true
+                                            }
                                             dataInputStream.read(byteArray)
                                             set.add(String(byteArray))
                                         }

--- a/harmony/src/main/java/com/frybits/harmony/Harmony.kt
+++ b/harmony/src/main/java/com/frybits/harmony/Harmony.kt
@@ -1050,6 +1050,8 @@ private class HarmonyTransaction(private val uuid: UUID = UUID.randomUUID()) : C
                                     val byteArray = try {
                                         ByteArray(size)
                                     } catch (e: OutOfMemoryError) { // This was a bug with an old transaction file.
+                                        _InternalHarmonyLog.e(LOG_TAG, "Received OutOfMemoryError while creating ByteArray")
+                                        _InternalHarmonyLog.recordException(e)
                                         return transactionSet to true
                                     }
                                     dataInputStream.read(byteArray)
@@ -1075,6 +1077,8 @@ private class HarmonyTransaction(private val uuid: UUID = UUID.randomUUID()) : C
                                     val byteArray = try {
                                         ByteArray(size)
                                     } catch (e: OutOfMemoryError) { // This was a bug with an old transaction file.
+                                        _InternalHarmonyLog.e(LOG_TAG, "Received OutOfMemoryError while creating ByteArray")
+                                        _InternalHarmonyLog.recordException(e)
                                         return transactionSet to true
                                     }
                                     dataInputStream.read(byteArray)
@@ -1098,6 +1102,8 @@ private class HarmonyTransaction(private val uuid: UUID = UUID.randomUUID()) : C
                                             val byteArray = try {
                                                 ByteArray(size)
                                             } catch (e: OutOfMemoryError) { // This was a bug with an old transaction file.
+                                                _InternalHarmonyLog.e(LOG_TAG, "Received OutOfMemoryError while creating ByteArray")
+                                                _InternalHarmonyLog.recordException(e)
                                                 return transactionSet to true
                                             }
                                             dataInputStream.read(byteArray)


### PR DESCRIPTION
This clears the transaction file created due to #22, and reported in #34.