### PR TITLE
Ensure Harmony Crypto `contains()` returns false if value is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Change Log
 
-### Version 1.2.6 / 2024-02-06
+### Version 1.2.6 / 2024-02-07
 - Fixes bug where Harmony Crypto `SharedPreferences.contains()` returns true even though the value is false [#56](https://github.com/pablobaxter/Harmony/issues/56)
 - Fixes bug in Harmony Crypto where `Editor.remove()` was not removing values
+- Fixes bug in Harmony Crypto where `null` values could not be set for String set
+  - **NOTE**: This change will cause previously `null` keys for `getStringSet()` to return a non-empty set in Harmony Crypto
 - Refactors internal code for Harmony Crypto
 - Removes unnecessary check in Harmony
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Change Log
 
+### Version 1.2.6 / 2024-02-06
+- Fixes bug where Harmony Crypto `SharedPreferences.contains()` returns true even though the value is false [#56](https://github.com/pablobaxter/Harmony/issues/56)
+- Fixes bug in Harmony Crypto where `Editor.remove()` was not removing values
+- Refactors internal code for Harmony Crypto
+- Removes unnecessary check in Harmony
+
 ### Version 1.2.5 / 2024-01-27
 - Upgraded several dependencies
 - Upgraded to AGP 8.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Change Log
 
-### Version 1.2.6 / 2024-02-07
+### Unreleased
 - Fixes bug where Harmony Crypto `SharedPreferences.contains()` returns true even though the value is false [#56](https://github.com/pablobaxter/Harmony/issues/56)
 - Fixes bug in Harmony Crypto where `Editor.remove()` was not removing values
 - Fixes bug in Harmony Crypto where `null` values could not be set for String set

--- a/crypto/src/androidTest/java/com/frybits/harmony/secure/test/EncryptedHarmonyTest.kt
+++ b/crypto/src/androidTest/java/com/frybits/harmony/secure/test/EncryptedHarmonyTest.kt
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith
 import kotlin.random.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
@@ -352,7 +353,7 @@ class EncryptedHarmonyTest {
     }
 
     @Test
-    fun testValueToNullContains() {
+    fun testStringValueToNullContains() {
         // Everything should be empty
         assertFalse { sharedPreferences.contains("test") }
 
@@ -367,6 +368,44 @@ class EncryptedHarmonyTest {
         sharedPreferences.edit { putString("test", null) }
 
         assertFalse { sharedPreferences.contains("test") }
+    }
+
+    @Test
+    fun testStringSetValueToNullContains() {
+        // Everything should be empty
+        assertFalse { sharedPreferences.contains("test") }
+
+        assertEquals(0, sharedPreferences.all.size)
+
+        val randomString = "${Random.nextInt()}"
+        sharedPreferences.edit { putStringSet("test", setOf(randomString)) }
+
+        assertTrue { sharedPreferences.contains("test") }
+        assertEquals(1, sharedPreferences.all.size)
+
+        sharedPreferences.edit { putStringSet("test", null) }
+
+        assertFalse { sharedPreferences.contains("test") }
+    }
+
+    @Test
+    fun testStringSetStringToNull() {
+        // Everything should be empty
+        assertFalse { sharedPreferences.contains("test") }
+
+        assertEquals(0, sharedPreferences.all.size)
+
+        val randomString = "${Random.nextInt()}"
+        sharedPreferences.edit { putStringSet("test", setOf(randomString, null)) }
+
+        assertTrue { sharedPreferences.contains("test") }
+        assertEquals(1, sharedPreferences.all.size)
+
+        val actual = sharedPreferences.getStringSet("test", null)
+        assertNotNull(actual)
+
+        val expected = setOf(randomString, null)
+        assertEquals(expected, actual)
     }
 
     @Test

--- a/crypto/src/androidTest/java/com/frybits/harmony/secure/test/EncryptedHarmonyTest.kt
+++ b/crypto/src/androidTest/java/com/frybits/harmony/secure/test/EncryptedHarmonyTest.kt
@@ -350,4 +350,48 @@ class EncryptedHarmonyTest {
         assertNull(unencryptedPrefs.getStringSet("test", null)) // This key is encrypted, so it should return null
         assertEquals(randomStringSet, sharedPreferences.getStringSet("test", null))
     }
+
+    @Test
+    fun testValueToNullContains() {
+        // Everything should be empty
+        assertFalse { sharedPreferences.contains("test") }
+
+        assertEquals(0, sharedPreferences.all.size)
+
+        val randomString = "${Random.nextInt()}"
+        sharedPreferences.edit { putString("test", randomString) }
+
+        assertTrue { sharedPreferences.contains("test") }
+        assertEquals(1, sharedPreferences.all.size)
+
+        sharedPreferences.edit { putString("test", null) }
+
+        assertFalse { sharedPreferences.contains("test") }
+    }
+
+    @Test
+    fun testRemove() {
+        // Everything should be empty
+        assertFalse { sharedPreferences.contains("test") }
+
+        assertEquals(0, sharedPreferences.all.size)
+
+        val randomString = "${Random.nextInt()}"
+        sharedPreferences.edit {
+            putString("test", randomString)
+            putString(null, randomString)
+        }
+
+        assertTrue { sharedPreferences.contains("test") }
+        assertTrue { sharedPreferences.contains(null) }
+        assertEquals(2, sharedPreferences.all.size)
+
+        sharedPreferences.edit { remove("test") }
+        assertFalse { sharedPreferences.contains("test") }
+        assertTrue { sharedPreferences.contains(null) }
+
+        sharedPreferences.edit { remove(null) }
+        assertFalse { sharedPreferences.contains("test") }
+        assertFalse { sharedPreferences.contains(null) }
+    }
 }

--- a/crypto/src/main/java/androidx/security/crypto/SecureHarmonyPreferences.kt
+++ b/crypto/src/main/java/androidx/security/crypto/SecureHarmonyPreferences.kt
@@ -44,6 +44,7 @@ import kotlin.text.Charsets.UTF_8
 internal const val KEY_KEYSET = "KEY_KEYSET"
 internal const val VALUE_KEYSET = "VALUE_KEYSET"
 private const val NULL_VALUE = "__NULL__"
+private val EMPTY_BYTE_ARRAY = byteArrayOf()
 
 private class SecureHarmonyPreferencesImpl(
     private val fileName: String,
@@ -57,9 +58,9 @@ private class SecureHarmonyPreferencesImpl(
     private inner class SecureEditor(private val editor: SharedPreferences.Editor) : SharedPreferences.Editor by editor {
 
         override fun putString(key: String?, value: String?): SharedPreferences.Editor {
-            val stringBytes = value?.toByteArray(UTF_8) ?: byteArrayOf()
+            val stringBytes = value?.toByteArray(UTF_8) ?: EMPTY_BYTE_ARRAY
             if (stringBytes.isEmpty()) {
-                putEncryptedObject(key, byteArrayOf())
+                putEncryptedObject(key, EMPTY_BYTE_ARRAY)
             } else {
                 val stringByteLength = stringBytes.size
                 val buffer = ByteBuffer.allocate(Int.SIZE_BYTES + Int.SIZE_BYTES + stringByteLength)
@@ -71,23 +72,27 @@ private class SecureHarmonyPreferencesImpl(
             return this
         }
 
-        override fun putStringSet(key: String?, values: MutableSet<String>?): SharedPreferences.Editor {
-            val mutableValues = values ?: setOf(NULL_VALUE)
-            val byteValues = arrayListOf<ByteArray>()
-            var totalBytes = mutableValues.size * Int.SIZE_BYTES
-            mutableValues.forEach { strValue ->
-                val byteValue = strValue.toByteArray(UTF_8)
-                byteValues.add(byteValue)
-                totalBytes += byteValue.size
+        override fun putStringSet(key: String?, values: MutableSet<String?>?): SharedPreferences.Editor {
+            if (values == null) {
+                putEncryptedObject(key, EMPTY_BYTE_ARRAY)
+            } else {
+                val byteValues = arrayListOf<ByteArray>()
+                var totalBytes = values.size * Int.SIZE_BYTES
+                values.forEach { strValue ->
+                    val v = strValue ?: NULL_VALUE
+                    val byteValue = v.toByteArray(UTF_8)
+                    byteValues.add(byteValue)
+                    totalBytes += byteValue.size
+                }
+                totalBytes += Int.SIZE_BYTES
+                val buffer = ByteBuffer.allocate(totalBytes)
+                buffer.putInt(EncryptedType.STRING_SET)
+                byteValues.forEach { bytes ->
+                    buffer.putInt(bytes.size)
+                    buffer.put(bytes)
+                }
+                putEncryptedObject(key, buffer.array())
             }
-            totalBytes += Int.SIZE_BYTES
-            val buffer = ByteBuffer.allocate(totalBytes)
-            buffer.putInt(EncryptedType.STRING_SET)
-            byteValues.forEach { bytes ->
-                buffer.putInt(bytes.size)
-                buffer.put(bytes)
-            }
-            putEncryptedObject(key, buffer.array())
             return this
         }
 
@@ -246,19 +251,20 @@ private class SecureHarmonyPreferencesImpl(
                     EncryptedType.FLOAT -> return buffer.float
                     EncryptedType.BOOLEAN -> return buffer.get() != 0.toByte()
                     EncryptedType.STRING_SET -> {
-                        val stringSet = ArraySet<String>()
+                        val stringSet = ArraySet<String?>()
                         while (buffer.hasRemaining()) {
                             val subStringLength = buffer.int
                             val subStringSlice = buffer.slice()
                             subStringSlice.limit(subStringLength)
                             buffer.position(buffer.position() + subStringLength)
-                            stringSet.add(UTF_8.decode(subStringSlice).toString())
+                            val s = UTF_8.decode(subStringSlice).toString()
+                            if (s == NULL_VALUE) {
+                                stringSet.add(null)
+                            } else {
+                                stringSet.add(s)
+                            }
                         }
-                        return if (stringSet.size == 1 && stringSet.valueAt(0) == NULL_VALUE) {
-                            null
-                        } else {
-                            stringSet
-                        }
+                        return stringSet
                     }
                     else -> return null
                 }

--- a/crypto/src/main/java/com/frybits/harmony/secure/EncryptedHarmony.kt
+++ b/crypto/src/main/java/com/frybits/harmony/secure/EncryptedHarmony.kt
@@ -39,7 +39,6 @@ import androidx.security.crypto.SecureHarmonyPreferences
  *  val sharedPreferences = context.getEncryptedHarmonySharedPreferences(
  *      "secret_shared_prefs",
  *      masterKeyAlias,
- *      context,
  *      EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
  *      EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
  *  )

--- a/crypto/src/main/java/com/frybits/harmony/secure/FileUtils.kt
+++ b/crypto/src/main/java/com/frybits/harmony/secure/FileUtils.kt
@@ -1,7 +1,7 @@
 @file:JvmName("_InternalCoreHarmony")
 @file:JvmMultifileClass
 
-package com.google.crypto.tink.integration.android
+package com.frybits.harmony.secure
 
 import android.content.Context
 import java.io.File

--- a/crypto/src/main/java/com/frybits/harmony/secure/HarmonyKeysetReader.kt
+++ b/crypto/src/main/java/com/frybits/harmony/secure/HarmonyKeysetReader.kt
@@ -1,4 +1,4 @@
-package com.google.crypto.tink.integration.android
+package com.frybits.harmony.secure
 
 import com.frybits.harmony.withFileLock
 import com.google.crypto.tink.KeysetReader
@@ -13,7 +13,7 @@ import java.io.FileNotFoundException
  *
  * Creates a [KeysetReader] that reads and hex-decodes keysets from the file passed into the constructor.
 */
-class HarmonyKeysetReader(private val keysetFile: File, private val keysetFileLock: File) : KeysetReader {
+internal class HarmonyKeysetReader(private val keysetFile: File, private val keysetFileLock: File) : KeysetReader {
 
     override fun read(): Keyset {
         return keysetFileLock.withFileLock(shared = true) {

--- a/crypto/src/main/java/com/frybits/harmony/secure/HarmonyKeysetWriter.kt
+++ b/crypto/src/main/java/com/frybits/harmony/secure/HarmonyKeysetWriter.kt
@@ -1,4 +1,4 @@
-package com.google.crypto.tink.integration.android
+package com.frybits.harmony.secure
 
 import android.annotation.SuppressLint
 import com.frybits.harmony.sync
@@ -16,12 +16,12 @@ import java.io.File
  *
  */
 @SuppressLint("CommitPrefEdits")
-class HarmonyKeysetWriter(private val keysetFile: File, private val keysetFileLock: File) : KeysetWriter {
+internal class HarmonyKeysetWriter(private val keysetFile: File, private val keysetFileLock: File) : KeysetWriter {
 
     override fun write(keyset: EncryptedKeyset) {
         keysetFileLock.withFileLock {
             keysetFile.outputStream().use {
-                keyset.writeTo(it)
+                keyset.toBuilder().clearKeysetInfo().build().writeTo(it)
                 it.sync()
             }
         }

--- a/harmony/src/main/java/com/frybits/harmony/FileUtils.kt
+++ b/harmony/src/main/java/com/frybits/harmony/FileUtils.kt
@@ -1,6 +1,5 @@
 package com.frybits.harmony
 
-import android.os.Build
 import android.system.Os
 import com.frybits.harmony.internal.FILE_UTILS_LOG_TAG
 import com.frybits.harmony.internal._InternalHarmonyLog
@@ -61,9 +60,5 @@ inline fun <T> File.withFileLock(shared: Boolean = false, block: () -> T): T? {
  * Helper function for performing an fsync() on the given [FileOutputStream]
  */
 fun FileOutputStream.sync() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        Os.fsync(fd)
-    } else {
-        fd.sync()
-    }
+    Os.fsync(fd)
 }


### PR DESCRIPTION
Fixes issue where values set to null were not removed (#56). Also fixes issue where String sets could not contain `null` values.